### PR TITLE
fixed a compiling error of max() on Windows7 Visual Studio 2015

### DIFF
--- a/ringbuffer.hpp
+++ b/ringbuffer.hpp
@@ -16,6 +16,10 @@
 #include <limits>
 #include <atomic>
 
+#if defined max
+#undef max
+#endif
+
 /*!
  * \brief Lock free, with no wasted slots ringbuffer implementation
  *


### PR DESCRIPTION
There is a compiling warning and error on Visual Studio 2015 as following:

1>------ Rebuild All started: Project: minidump, Configuration: Debug Win32 ------
1>  udp_capture.cpp
1>......\ringbuffer.hpp(348): warning C4003: not enough actual parameters for macro 'max'
1>......\ringbuffer.hpp(348): error C2589: '(': illegal token on right side of '::'
1>  ......\ringbuffer.hpp(350): note: see reference to class template instantiation 'Ringbuffer<T,buffer_size,wmo_multi_core,cacheline_size,index_t>' being compiled
1>......\ringbuffer.hpp(348): error C2059: syntax error: '::'
1>......\ringbuffer.hpp(348): error C2334: unexpected token(s) preceding ':'; skipping apparent function body
1>......\ringbuffer.hpp(350): error C2143: syntax error: missing ')' before ';'
1>......\ringbuffer.hpp(350): error C2059: syntax error: ')'
1>......\ringbuffer.hpp(350): error C2238: unexpected token(s) preceding ';'
1>......\ringbuffer.hpp(350): fatal error C1201: unable to continue after syntax error in class template definition
1>  main.cpp
1>  Generating Code...
========== Rebuild All: 0 succeeded, 1 failed, 0 skipped ==========

Signed-off-by: zhengfish <zhengfish@gmail.com>
