### PR TITLE
Please include type_traits for std::is_trivial for older gcc

### DIFF
--- a/ringbuffer.hpp
+++ b/ringbuffer.hpp
@@ -15,6 +15,7 @@
 #include <stddef.h>
 #include <limits>
 #include <atomic>
+#include <type_traits>
 
 namespace jnk0le
 {


### PR DESCRIPTION
I met a compilation error on gcc 5:

```
include/ringbuffer.hpp:350:17: error: "is_trivial™ is not a member of "std™
   static_assert(std::is_trivial<T>::value, "non trivial objects will currently break");
                 ^
include/ringbuffer.hpp:350:34: error: expected primary-expression before ">™ token
   static_assert(std::is_trivial<T>::value, "non trivial objects will currently break");
                                  ^
include/ringbuffer.hpp:350:35: error: "::value" has not been declared
   static_assert(std::is_trivial<T>::value, "non trivial objects will currently break");
                                   ^
```

It is caused by lack of include `<type_traits>`.
This PR is to solve it.

PS: I know it is very trivial patch. So you can miss this PR and fix it on HEAD.
